### PR TITLE
Added to ReadMe instruction to run on 5173

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cd TuneOut
 ```
 
 ### 2. Setup Frontend
+ *The app must be run on port 5173.*
 
 ```bash
 cd TuneOut


### PR DESCRIPTION
Added on the README that our app must be run on port 5173.
(This is due to CORS issues)